### PR TITLE
Rename rpm gem to rpm2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 
 # RPM bindings for ruby
 
-![maintained](https://img.shields.io/maintenance/yes/2016.svg) [![Build Status](https://travis-ci.org/dmacvicar/ruby-rpm-ffi.svg?branch=master)](https://travis-ci.org/dmacvicar/ruby-rpm-ffi)
-
-* http://github.com/dmacvicar/ruby-rpm-ffi
 
 # WARNING
 
@@ -70,7 +67,7 @@ This gem:
 
 * Is pure ruby
 * Is documented
-* Has as a goal to support only the latest rpm version plus the ones in 
+* Has as a goal to support only the latest rpm version plus the ones in
   use some releases back in popular rpm based distros
 * Uses FFI, so it should work with other interpreters
   (Because https://github.com/rubinius/rubinius/issues/682 it currently does
@@ -373,4 +370,3 @@ rake docker_test
   Copyright © 2002 Kenta Murata. Relicensed with his permission.
 
 Licensed under the MIT license. See MIT-LICENSE for details.
-

--- a/lib/rpm2.rb
+++ b/lib/rpm2.rb
@@ -1,0 +1,1 @@
+require_relative "./rpm"

--- a/rpm2.gemspec
+++ b/rpm2.gemspec
@@ -1,18 +1,22 @@
 # -*- encoding: utf-8 -*-
 
-$LOAD_PATH.push File.expand_path('../lib', __FILE__)
-require 'rpm/gem_version'
+require_relative 'lib/rpm/gem_version'
 
 Gem::Specification.new do |s|
-  s.name        = 'rpm'
+  s.name        = 'rpm2'
   s.version     = RPM::GEM_VERSION
-  s.authors     = ['Duncan Mac-Vicar P.']
+  s.authors     = ['Duncan Mac-Vicar P.', 'ManageIQ Developers']
   s.email       = ['dmacvicar@suse.de']
-  s.homepage    = ''
+  s.homepage    = 'https://github.com/ManageIQ/ruby-rpm-ffi2'
+  s.licenses    = ['MIT']
   s.summary     = 'Ruby bindings for rpm (package manager)'
   s.description = 'Ruby bindings for rpm. Almost a drop-in replacement for ruby-rpm. Uses FFI.'
 
-  s.rubyforge_project = 'rpm'
+  s.metadata['allowed_push_host']     = 'https://rubygems.org'
+  s.metadata['rubygems_mfa_required'] = 'true'
+  s.metadata['homepage_uri']          = s.homepage
+  s.metadata['source_code_uri']       = s.homepage
+  s.metadata['changelog_uri']         = "#{s.homepage}/blob/master/ChangeLog"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
https://github.com/dmacvicar/ruby-rpm-ffi is not being maintained any longer and thus https://rubygems.org/gems/rpm cannot be used.

Rename this gem rpm2 while maintaining the old `require "rpm"` and `RPM` namespace behavior
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
