### PR TITLE
Do not use headerNVR in Package.version

### DIFF
--- a/lib/rpm/package.rb
+++ b/lib/rpm/package.rb
@@ -261,15 +261,7 @@ module RPM
 
     # @return [Version] Version for this package
     def version
-      v_ptr = ::FFI::MemoryPointer.new(:pointer, 1)
-      r_ptr = ::FFI::MemoryPointer.new(:pointer, 1)
-
-      RPM::C.headerNVR(ptr, nil, v_ptr, r_ptr)
-      v = v_ptr.read_pointer.read_string
-      r = r_ptr.read_pointer.read_string
-      v_ptr.free
-      r_ptr.free
-      Version.new(v, r, self[:epoch])
+      Version.new(self[:version], self[:release], self[:epoch])
     end
 
     # String representation of the package: "name-version-release-arch"

--- a/test/test_package.rb
+++ b/test/test_package.rb
@@ -13,7 +13,6 @@ class RPMHeaderTests < Minitest::Test
     req = RPM::Require.new('simple', RPM::Version.new('1.0', '0'), RPM::SENSE_GREATER | RPM::SENSE_EQUAL, nil)
     assert req.satisfy?(pkg)
 
-    skip("NoMethodError: undefined method `headerNVR' for module RPM::C")
     assert_equal 'simple-1.0-0-i586', pkg.to_s
 
     assert_equal '3b5f9d468c877166532c662e29f43bc3', pkg.signature

--- a/test/test_transaction.rb
+++ b/test/test_transaction.rb
@@ -125,7 +125,6 @@ class RPMTransactionTests < Minitest::Test
   end
 
   def test_install_with_custom_callback
-    skip("NoMethodError: undefined method `headerNVR' for RPM::C:Module")
     pkg = RPM::Package.open(fixture(PACKAGE_FILENAME))
 
     Dir.mktmpdir do |dir|


### PR DESCRIPTION
It is no longer available with rpm >= 4.14

Copied commit from https://github.com/dmacvicar/ruby-rpm-ffi/pull/14 credit to @pterjan for the fix