### PR TITLE
Detect librpm.so.9

### DIFF
--- a/lib/rpm/c.rb
+++ b/lib/rpm/c.rb
@@ -6,6 +6,7 @@ module RPM
 
     begin
       ffi_lib ['rpm',
+               'librpm.so.9',
                'librpm.so.8', # Tumbleweed
                'librpm.so.7', # fedora 23
                'librpm.so.3', 'librpm.so.2', 'librpm.so.1']


### PR DESCRIPTION
Add support for librpm.so.9 which is used by the EL9 distributions, e.g.: CentOS Stream 9, Rocky 9, RHEL9, etc...

Copied commit from https://github.com/dmacvicar/ruby-rpm-ffi/pull/15
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
