### PR TITLE
Cleanup warnings

### DIFF
--- a/lib/rpm.rb
+++ b/lib/rpm.rb
@@ -41,7 +41,6 @@ module RPM
   # @param [String] name Name of the macro
   # @return [String] value of macro +name+
   def self.[](name)
-    val = ''
     buffer = ::FFI::MemoryPointer.new(:pointer, 1024)
     buffer.write_string("%{#{name}}")
     ret = RPM::C.expandMacros(nil, nil, buffer, 1024)

--- a/lib/rpm/c/rpmio.rb
+++ b/lib/rpm/c/rpmio.rb
@@ -12,8 +12,6 @@ module RPM
 
     attach_function 'fdDup', [:int], :FD_t
 
-    attach_function 'Fstrerror', [:FD_t], :string
-
     attach_function 'fdLink', [:pointer], :FD_t
   end
 end

--- a/lib/rpm/c/rpmts.rb
+++ b/lib/rpm/c/rpmts.rb
@@ -62,8 +62,6 @@ module RPM
     attach_function 'rpmtsFlags', [:rpmts], :rpmtransFlags
     attach_function 'rpmtsSetFlags', %i[rpmts rpmtransFlags], :rpmtransFlags
     # ...
-    attach_function 'rpmtsSetNotifyCallback', %i[rpmts rpmCallbackFunction rpmCallbackData], :int
-    # ...
     attach_function 'rpmtsCreate', [], :rpmts
     attach_function 'rpmtsAddInstallElement', %i[rpmts header fnpyKey int rpmRelocation], :int
     attach_function 'rpmtsAddEraseElement', %i[rpmts header int], :int

--- a/lib/rpm/package.rb
+++ b/lib/rpm/package.rb
@@ -215,7 +215,6 @@ module RPM
     # @return [String, Fixnum, Array<String>, Array<Fixnum>, nil]
     #   The value of the entry
     def [](tag)
-      val = nil
       tagc = ::FFI::AutoPointer.new(RPM::C.rpmtdNew, Package.method(:release_td))
 
       return nil if RPM::C.headerGet(ptr, tag, tagc,
@@ -316,7 +315,7 @@ module RPM
         fd = RPM::C.Fopen(filename, 'r')
         raise "#{filename} : #{RPM::C.Fstrerror(fd)}" if RPM::C.Ferror(fd) != 0
         RPM.transaction do |ts|
-          rc = RPM::C.rpmReadPackageFile(ts.ptr, fd, filename, hdr)
+          RPM::C.rpmReadPackageFile(ts.ptr, fd, filename, hdr)
         end
       ensure
         RPM::C.Fclose(fd) unless fd.nil?

--- a/lib/rpm/transaction.rb
+++ b/lib/rpm/transaction.rb
@@ -164,8 +164,6 @@ module RPM
     # end
     # @yield [CallbackData] sig Transaction progress
     def commit
-      flags = RPM::C::TransFlags[:none]
-
       callback = proc do |hdr, type, amount, total, key_ptr, data_ignored|
         key_id = key_ptr.address
         key = @keys.include?(key_id) ? @keys[key_id] : nil

--- a/lib/rpm/version.rb
+++ b/lib/rpm/version.rb
@@ -91,7 +91,7 @@ module RPM
     #
     def <=>(other)
       RPM::Utils.check_type(other, RPM::Version)
-      ret = RPM::C.rpmvercmp(to_vre_epoch_zero, other.to_vre_epoch_zero)
+      RPM::C.rpmvercmp(to_vre_epoch_zero, other.to_vre_epoch_zero)
     end
 
     # @param [Version] other Version to compare against
@@ -110,7 +110,7 @@ module RPM
     # @return [String]
     # @note The epoch is not included
     def to_vr
-      vr = @r.nil? ? @v.to_s : "#{@v}-#{@r}"
+      @r.nil? ? @v.to_s : "#{@v}-#{@r}"
     end
 
     # String representation in the form "e:v-r"
@@ -118,7 +118,7 @@ module RPM
     # @note The epoch is included if present
     def to_vre(_opts = {})
       vr = to_vr
-      vre = @e.nil? ? vr : "#{@e}:#{vr}"
+      @e.nil? ? vr : "#{@e}:#{vr}"
     end
 
     # Alias for +to_vr+
@@ -140,7 +140,7 @@ module RPM
     # @note The epoch is included always. As 0 if not present
     def to_vre_epoch_zero
       vr = to_vr
-      vre = @e.nil? ? "0:#{vr}" : "#{@e}:#{vr}"
+      @e.nil? ? "0:#{vr}" : "#{@e}:#{vr}"
     end
   end
 end

--- a/test/test_file.rb
+++ b/test/test_file.rb
@@ -4,7 +4,7 @@ class RPMFileTests < Minitest::Test
   def test_link_to
     f = RPM::File.new('path', 'md5sum', nil, 42, 1,
                       'owner', 'group', 43, 0o777, 44, 45)
-    assert_equal(nil, f.link_to)
+    assert_nil(f.link_to)
     f = RPM::File.new('path', 'md5sum', 'link_to', 42, 1,
                       'owner', 'group', 43, 0o777, 44, 45)
     assert_equal('link_to', f.link_to)

--- a/test/test_package.rb
+++ b/test/test_package.rb
@@ -1,6 +1,6 @@
 require File.join(File.dirname(__FILE__), 'helper')
 
-class RPMHeaderTests < Minitest::Test
+class RPMPackageTests < Minitest::Test
   def test_create
     pkg = RPM::Package.create('foo', RPM::Version.new('1.0'))
     assert_equal 'foo', pkg.name

--- a/test/test_problem.rb
+++ b/test/test_problem.rb
@@ -1,6 +1,6 @@
 require File.join(File.dirname(__FILE__), 'helper')
 
-class RPMHeaderTests < Minitest::Test
+class RPMProblemTests < Minitest::Test
   def test_create
     problem = RPM::Problem.create(:requires, 'foo-1.0-0', 'foo.rpm', 'bar-1.0-0', 'Hello', 1)
     assert_equal 'foo.rpm', problem.key

--- a/test/test_rpm.rb
+++ b/test/test_rpm.rb
@@ -10,8 +10,6 @@ class RPMRPMTests < Minitest::Test
     # assert_raise(NameError) { RPM::LOG_ALERT }
 
     # require 'rpm/compat'
-    # Nothing should be raised by the following statement
-    RPM::LOG_ALERT
     assert_equal RPM::LOG_ALERT, RPM::LOG[:alert]
   end
 


### PR DESCRIPTION
@agrare This fixes all of the warnings emitted in the tests. Forest for the trees 😄 


```
/src/lib/rpm.rb:44: warning: assigned but unused variable - val
/usr/share/gems/gems/ffi-1.17.1-aarch64-linux-gnu/lib/ffi/function.rb:65: warning: method redefined; discarding old Fstrerror
/usr/share/gems/gems/ffi-1.17.1-aarch64-linux-gnu/lib/ffi/function.rb:65: warning: method redefined; discarding old Fstrerror
/usr/share/gems/gems/ffi-1.17.1-aarch64-linux-gnu/lib/ffi/function.rb:65: warning: method redefined; discarding old rpmtsSetNotifyCallback
/usr/share/gems/gems/ffi-1.17.1-aarch64-linux-gnu/lib/ffi/function.rb:65: warning: method redefined; discarding old rpmtsSetNotifyCallback
/src/lib/rpm/package.rb:218: warning: assigned but unused variable - val
/src/lib/rpm/package.rb:319: warning: assigned but unused variable - rc
/src/lib/rpm/transaction.rb:167: warning: assigned but unused variable - flags
/src/lib/rpm/version.rb:94: warning: assigned but unused variable - ret
/src/lib/rpm/version.rb:113: warning: assigned but unused variable - vr
/src/lib/rpm/version.rb:121: warning: assigned but unused variable - vre
/src/lib/rpm/version.rb:143: warning: assigned but unused variable - vre
/src/test/test_problem.rb:4: warning: method redefined; discarding old test_create
/src/test/test_package.rb:4: warning: previous definition of test_create was here
/src/test/test_rpm.rb:14: warning: possibly useless use of :: in void context

DEPRECATED: Use assert_nil if expecting nil from /src/test/test_file.rb:7. This will fail in Minitest 6.
```

As discussed, I left in this one, to remind us to actually check the return value

```
/src/lib/rpm.rb:47: warning: assigned but unused variable - ret
```