### PR TITLE
Update rpmExpandMacros MemoryPointer usage

### DIFF
--- a/lib/rpm.rb
+++ b/lib/rpm.rb
@@ -42,13 +42,13 @@ module RPM
   # @return [String] value of macro +name+
   def self.[](name)
     if C::rpm_version_code >= ((4 << 16) + (14 << 8) + (0 << 0))
-      obuf = ::FFI::MemoryPointer.new(:pointer)
+      obuf = ::FFI::MemoryPointer.new(:pointer, 1)
       sbuf = FFI::MemoryPointer.from_string("%{#{name}}")
       ret = RPM::C.rpmExpandMacros(nil, sbuf, obuf, 0)
       raise if ret < 0
 
-      val = obuf.get_pointer(0)
-      val.read_string
+      val = obuf.read_pointer
+      val.nil? ? nil : val.read_string
     else
       buffer = ::FFI::MemoryPointer.new(:pointer, 1024)
       buffer.write_string("%{#{name}}")


### PR DESCRIPTION
Change to match the examples for a string as an output parameter not just a general object as an output parameter.  They way I was used to doing this was for a object not specifically a string.

https://msp-greg.github.io/ffi/file.Examples.html#single-string

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
