### PR TITLE
Force the platform to linux/amd64 in tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -38,7 +38,7 @@ end
 def each_dockerfile(platform)
   platform ||= "*"
   Dir.glob("_docker/Dockerfile.#{platform}").each do |dockerfile|
-    tag = "ruby-rpm-ffi:#{File.extname(dockerfile).delete('.')}"
+    tag = "localhost/ruby-rpm-ffi:#{File.extname(dockerfile).delete('.')}"
     yield dockerfile, tag
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -46,13 +46,13 @@ end
 desc "Build the docker images for test"
 task :docker_images, [:platform] do |_t, args|
   each_dockerfile(args[:platform]) do |dockerfile, tag|
-    sh "podman build -f #{dockerfile} -t #{tag} ."
+    sh "podman build --platform=linux/amd64 -f #{dockerfile} -t #{tag} ."
   end
 end
 
 desc "Run the tests from within the docker images"
 task :docker_test, [:platform] do |_t, args|
   each_dockerfile(args[:platform]) do |dockerfile, tag|
-    sh "podman run --rm -ti -v #{Dir.pwd}:/src #{tag} rake test"
+    sh "podman run --platform=linux/amd64 --rm -ti -v #{Dir.pwd}:/src #{tag} rake test"
   end
 end

--- a/_docker/Dockerfile.ubi8
+++ b/_docker/Dockerfile.ubi8
@@ -1,4 +1,4 @@
-FROM docker.io/redhat/ubi8:latest
+FROM registry.access.redhat.com/ubi8/ubi
 RUN dnf module -y enable ruby:3.1
 RUN dnf install -y ruby git
 RUN gem install bundler

--- a/_docker/Dockerfile.ubi9
+++ b/_docker/Dockerfile.ubi9
@@ -1,4 +1,4 @@
-FROM docker.io/redhat/ubi9:latest
+FROM registry.access.redhat.com/ubi9/ubi
 RUN dnf module -y enable ruby:3.3
 RUN dnf install -y ruby git
 RUN gem install bundler


### PR DESCRIPTION
The tests are currently build assuming amd64 platforms. Eventually, we can unlock this, but for now this causes the following error in tests on arm system, such as a Mac M1.

    RPMTransactionTests#test_install_with_custom_callback [test/test_transaction.rb:150]:
    package simple-1.0-0-i586 should be installed

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
